### PR TITLE
Update the gem to version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ RobertoBarros.quote #=> Está um ótimo dia para programar.
                             `:oyyyssoooooo++++++++///////////::/:-``    ```..``.`...-:/dmNNNN/      
                            .ys:/ssssooo++++++///+///////////::-.`       ``..```````..-hmmNNNN/      
                           .dNy/--+ooooo++++++///+//////:::::-`         ```.`````````.hmmmNNNN/  
+
+## Versioning
+
+This gem abides by [Semantic Versioning](www.semver.org) 2.0.0. The API is described in comments to each method.

--- a/lib/data.yml
+++ b/lib/data.yml
@@ -4,6 +4,9 @@ pt-BR:
     "A pessoa escreve Rubens nos Trilhos e desenha uma rodovia.",
     "A vida é muito curta para desperdiçar programando em Java.",
     "E aí você toma um erro no meio da fuça!",
+    "Em 2019, performance se resolve com dinheiro.",
+    "Em programação, ou tem 0, ou tem 1, ou tem vários.",
+    "Essa é a mágica, que é mágica nenhuma, que o Rails faz.",
     "Está um ótimo dia para programar.",
     "Eu acho que quem tatua o rosto não entende como a sociedade funciona.",
     "Lutador de sumô não limpa a bunda sozinho.",
@@ -19,13 +22,10 @@ pt-BR:
     "Quando você está programando, seu pior inimigo é você mesmo.",
     "Reboot quem dá é a vida.",
     "Scrum dá para aprender em 15 minutos, rsrsrs",
+    "Se começa com 'eco', não pode ser bom.",
     "Se o código não é simples, não é Ruby.",
     "Ué?",
-    "Um site nunca fica pronto. Mas você precisa entregar em algum momento.",
-    "Essa é a mágica, que é mágica nenhuma que o rails faz.",
-    "Em programação ou tem 0 ou tem 1 ou tem vários.",
-    "Se começa com 'eco', não pode ser bom.",
-    "Em 2019, performance se resolve com dinheiro."
+    "Um site nunca fica pronto. Mas você precisa entregar em algum momento."
   ]
   facts: [
     "Um belo dia, Roberto Barros viu um menino cabisbaixo na calçada,

--- a/lib/roberto_barros.rb
+++ b/lib/roberto_barros.rb
@@ -4,7 +4,7 @@ require 'yaml'
 
 # Return quotes and truths about the great Roberto Barros
 class RobertoBarros
-  DATA = YAML.safe_load(File.open('./data.yml'))
+  DATA = YAML.load_file(File.join(__dir__, 'data.yml'))
 
   # Take no arguments. Return a quote straight from the mouth of the great
   # Roberto Barros himself.

--- a/lib/roberto_barros.rb
+++ b/lib/roberto_barros.rb
@@ -1,21 +1,32 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
+# Return quotes and truths about the great Roberto Barros
 class RobertoBarros
-  DATA = YAML.load(File.open('./data.yml'))
+  DATA = YAML.safe_load(File.open('./data.yml'))
 
+  # Take no arguments. Return a quote straight from the mouth of the great
+  # Roberto Barros himself.
   def self.quote
-    return DATA['pt-BR']['quotes'].sample
+    DATA['pt-BR']['quotes'].sample
   end
 
+  # Take no arguments. Return a quote brilliantly translated into International
+  # Programmers' Language.
   def self.in_ingrish
-    return DATA['en']['quotes'].sample
+    DATA['en']['quotes'].sample
   end
 
+  # Take no arguments. Return a Chuck Norris-style fact (with the difference
+  # that these are true) about the great Roberto Barros.
   def self.fact
-    return DATA['pt-BR']['facts'].sample
+    DATA['pt-BR']['facts'].sample
   end
 
-  def self.is_genius?
-    return true
+  # Take no arguments. Return a boolean of whether the great Roberto Barros is
+  # a genius.
+  def self.genius?
+    true
   end
 end

--- a/roberto_barros.gemspec
+++ b/roberto_barros.gemspec
@@ -1,12 +1,15 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name        = 'roberto_barros'
-  s.version     = '0.0.4'
+  s.version     = '1.0.0'
   s.date        = '2019-05-16'
-  s.summary     = "Roberto Barros"
-  s.description = "A simple gem that randomly generates quotes from the great Roberto Barros."
-  s.authors     = ["davisjr2000"]
+  s.summary     = 'Roberto Barros'
+  s.description = "A simple gem that randomly generates quotes from \
+                  the great Roberto Barros."
+  s.authors     = ['davisjr2000']
   s.email       = 'davisrobertosouza@gmail.com'
-  s.files       = ["lib/roberto_barros.rb"]
+  s.files       = ['lib/roberto_barros.rb']
   s.homepage    = 'https://github.com/davisjr2000/roberto-barros'
   s.license     = 'MIT'
 end


### PR DESCRIPTION
I did several things here.

- In the YAML file, I put the quotes back in alphabetical order. I recommend keeping it that way in future PRs.
- I added stuff to please Rubocop, such as the "frozen string literal: true" comment at the top and replacing double quote marks with single ones. This also replaces the YAML gem call from `load` to `safe_load`. Loading files can sometimes be a security risk.
- I bumped the gem version to 1.0.0, in accordance with [semantic versioning](www.semver.org). SemVer says that, when the project's API changes in a backwards-incompatible way, the first version number (major) should be increased and the other two (minor and patch) be reset to zero.

The breaking change I made, suggested by Rubocop, was to change the predicate method `is_genius?` to simply `genius?`.